### PR TITLE
51 problems getting started with readme example

### DIFF
--- a/scripts/performance/astropy_conv.py
+++ b/scripts/performance/astropy_conv.py
@@ -4,8 +4,10 @@ from astropy import units as u
 
 import numpy as np
 
-a: Annotated[Any, "meters"] = np.random.rand(100000) * u.m
-b: Annotated[Any, "hours"] = np.random.rand(100000) * u.h
+rng = np.random.default_rng()
+
+a: Annotated[Any, "meters"] = rng.random(100000) * u.m
+b: Annotated[Any, "hours"] = rng.random(100000) * u.h
 
 
 @u.quantity_input(x=u.m, y=u.s)

--- a/scripts/performance/astropy_noconv.py
+++ b/scripts/performance/astropy_noconv.py
@@ -4,10 +4,10 @@ from astropy import units as u
 
 import numpy as np
 
-np.random.seed(0)
+rng = np.random.default_rng(0)
 
-a: Annotated[Any, "meters"] = np.random.rand(100000) * u.m
-b: Annotated[Any, "seconds"] = np.random.rand(100000) * u.s
+a: Annotated[Any, "meters"] = rng.random(100000) * u.m
+b: Annotated[Any, "seconds"] = rng.random(100000) * u.s
 
 
 @u.quantity_input(x=u.m, y=u.s)

--- a/scripts/performance/baseline_conv.py
+++ b/scripts/performance/baseline_conv.py
@@ -5,8 +5,10 @@ from typing import Annotated, Any
 
 import numpy as np
 
-a: Annotated[Any, "meters"] = np.random.rand(100000)
-b: Annotated[Any, "hours"] = np.random.rand(100000) / 3600
+rng = np.random.default_rng()
+
+a: Annotated[Any, "meters"] = rng.random(100000)
+b: Annotated[Any, "hours"] = rng.random(100000) / 3600
 
 
 def g(

--- a/scripts/performance/baseline_noconv.py
+++ b/scripts/performance/baseline_noconv.py
@@ -3,8 +3,10 @@ from typing import Annotated, Any
 
 import numpy as np
 
-a: Annotated[Any, "meters"] = np.random.rand(100000)
-b: Annotated[Any, "seconds"] = np.random.rand(100000)
+rng = np.random.default_rng()
+
+a: Annotated[Any, "meters"] = rng.random(100000)
+b: Annotated[Any, "seconds"] = rng.random(100000)
 
 
 def g(

--- a/scripts/performance/impunity_conv.py
+++ b/scripts/performance/impunity_conv.py
@@ -6,12 +6,16 @@ from typing import Annotated, Any
 import numpy as np
 from impunity import impunity
 
-a: Annotated[Any, "meters"] = np.random.rand(100000)
-b: Annotated[Any, "hours"] = np.random.rand(100000)
+rng = np.random.default_rng()
+
+a: Annotated[Any, "meters"] = rng.random(100000)
+b: Annotated[Any, "hours"] = rng.random(100000)
 
 
 @impunity(rewrite="log.txt")
-def g(x: Annotated[Any, "meters"], y: Annotated[Any, "hours"]) -> Annotated[Any, "m/s"]:
+def g(
+    x: Annotated[Any, "meters"], y: Annotated[Any, "hours"]
+) -> Annotated[Any, "m/s"]:
     return x / y
 
 

--- a/scripts/performance/impunity_noconv.py
+++ b/scripts/performance/impunity_noconv.py
@@ -6,8 +6,10 @@ from typing import Annotated, Any
 import numpy as np
 from impunity import impunity
 
-a: Annotated[Any, "meters"] = np.random.rand(100000)
-b: Annotated[Any, "seconds"] = np.random.rand(100000)
+rng = np.random.default_rng()
+
+a: Annotated[Any, "meters"] = rng.random(100000)
+b: Annotated[Any, "seconds"] = rng.random(100000)
 
 
 @impunity(rewrite="log_no.txt")

--- a/scripts/performance/numericalunits_conv.py
+++ b/scripts/performance/numericalunits_conv.py
@@ -4,8 +4,10 @@ from numericalunits import hour, m, s
 
 import numpy as np
 
-a: Annotated[Any, "meters"] = np.random.rand(100000) * m
-b: Annotated[Any, "hours"] = np.random.rand(100000) * hour
+rng = np.random.default_rng()
+
+a: Annotated[Any, "meters"] = rng.random(100000) * m
+b: Annotated[Any, "hours"] = rng.random(100000) * hour
 
 
 def g(

--- a/scripts/performance/numericalunits_noconv.py
+++ b/scripts/performance/numericalunits_noconv.py
@@ -4,8 +4,10 @@ from numericalunits import m, s
 
 import numpy as np
 
-a: Annotated[Any, "meters"] = np.random.rand(100000) * m
-b: Annotated[Any, "hours"] = np.random.rand(100000) * s
+rng = np.random.default_rng()
+
+a: Annotated[Any, "meters"] = rng.random(100000) * m
+b: Annotated[Any, "hours"] = rng.random(100000) * s
 
 
 def g(

--- a/scripts/performance/pint_conv.py
+++ b/scripts/performance/pint_conv.py
@@ -9,9 +9,10 @@ import numpy as np
 
 ureg = pint.UnitRegistry()
 Q_ = ureg.Quantity
+rng = np.random.default_rng()
 
-a: Annotated[Any, "meters"] = Q_(np.random.rand(100000), "meter")
-b: Annotated[Any, "seconds"] = Q_(np.random.rand(100000), "hours")
+a: Annotated[Any, "meters"] = Q_(rng.random(100000), "meter")
+b: Annotated[Any, "seconds"] = Q_(rng.random(100000), "hours")
 
 
 @ureg.wraps(None, ("meter", "seconds"))

--- a/scripts/performance/pint_noconv.py
+++ b/scripts/performance/pint_noconv.py
@@ -9,9 +9,10 @@ import numpy as np
 
 ureg = pint.UnitRegistry()
 Q_ = ureg.Quantity
+rng = np.random.default_rng()
 
-a: Annotated[Any, "meters"] = Q_(np.random.rand(100000), "meter")
-b: Annotated[Any, "seconds"] = Q_(np.random.rand(100000), "seconds")
+a: Annotated[Any, "meters"] = Q_(rng.random(100000), "meter")
+b: Annotated[Any, "seconds"] = Q_(rng.random(100000), "seconds")
 
 
 @ureg.wraps(None, ("meter", "seconds"))

--- a/scripts/performance/quantities_conv.py
+++ b/scripts/performance/quantities_conv.py
@@ -4,8 +4,10 @@ import quantities as pq
 
 import numpy as np
 
-a: Annotated[Any, "meters"] = np.random.rand(100000) * pq.m
-b: Annotated[Any, "hours"] = np.random.rand(100000) * pq.h
+rng = np.random.default_rng()
+
+a: Annotated[Any, "meters"] = rng.random(100000) * pq.m
+b: Annotated[Any, "hours"] = rng.random(100000) * pq.h
 
 
 def g(

--- a/scripts/performance/quantities_noconv.py
+++ b/scripts/performance/quantities_noconv.py
@@ -4,8 +4,10 @@ import quantities as pq
 
 import numpy as np
 
-a: Annotated[Any, "meters"] = np.random.rand(100000) * pq.m
-b: Annotated[Any, "seconds"] = np.random.rand(100000) * pq.s
+rng = np.random.default_rng()
+
+a: Annotated[Any, "meters"] = rng.random(100000) * pq.m
+b: Annotated[Any, "seconds"] = rng.random(100000) * pq.s
 
 
 def g(

--- a/src/impunity/visitor.py
+++ b/src/impunity/visitor.py
@@ -115,10 +115,7 @@ class Visitor(ast.NodeTransformer):
         # coloffset = getattr(node, "coloffset", 0)
         firstlineno = getattr(self.fun.__code__, "co_firstlineno", 0)
         filename = getattr(self.fun.__code__, "co_filename")
-        return (
-            f"{filename}:{firstlineno + lineno - 1} "
-            f"(in {self.fun.__name__}) "
-        )
+        return f"{filename}:{firstlineno + lineno - 1} " f"(in {self.fun.__name__}) "
 
     def get_annotation_unit(self, node: ast.expr) -> Optional[str]:
         """
@@ -155,6 +152,11 @@ class Visitor(ast.NodeTransformer):
             if isinstance(unit_node, ast.Constant):
                 unit = unit_node.value
 
+        # case where node's parent is an AnnAssign
+        elif isinstance(node, ast.Name):
+            if isinstance(node.parent, ast.AnnAssign):
+                unit = self.get_node_unit(node).unit
+
         return unit
 
     def visit(self, root: ast.AST) -> ast.AST:
@@ -190,9 +192,7 @@ class Visitor(ast.NodeTransformer):
     @overload
     def get_func(self, name: str, module: str) -> None | Callable[..., Any]: ...
 
-    def get_func(
-        self, name: str, module: None | str = None
-    ) -> None | ast.FunctionDef | Callable[..., Any]:
+    def get_func(self, name: str, module: None | str = None) -> None | ast.FunctionDef | Callable[..., Any]:
         result: None | ast.FunctionDef | Callable[..., Any] = None
 
         if module is not None:
@@ -264,9 +264,7 @@ class Visitor(ast.NodeTransformer):
                 e10 = r10.to(expected_unit)
 
                 if r0.m == e0.m:
-                    conv_value = expected_pint_unit.from_(  # type: ignore
-                        received_pint_unit
-                    ).m
+                    conv_value = expected_pint_unit.from_(received_pint_unit).m  # type: ignore
 
                     if conv_value == 1:
                         new_node = received_node
@@ -278,11 +276,7 @@ class Visitor(ast.NodeTransformer):
                         )
 
                 elif (e1.m - e0.m) == 1:
-                    conv_value = (
-                        expected_pint_unit.from_(  # type: ignore
-                            received_pint_unit
-                        ).m
-                    ) - 1
+                    conv_value = (expected_pint_unit.from_(received_pint_unit).m) - 1  # type: ignore
 
                     # if conv_value == 0:
                     #     new_node = received_node
@@ -320,9 +314,7 @@ class Visitor(ast.NodeTransformer):
 
     def module_loading(self) -> None:
         # Adding all annotations from own module
-        annotations = getattr(
-            sys.modules[self.fun.__module__], "__annotations__", None
-        )
+        annotations = getattr(sys.modules[self.fun.__module__], "__annotations__", None)
         if annotations is not None:
             for name, anno in annotations.items():
                 if is_annotated(anno):
@@ -331,7 +323,9 @@ class Visitor(ast.NodeTransformer):
                     self.vars[name] = anno
 
         # Adding all annotations from imported modules
-        for _, val in self.fun_globals.items():
+        for var_name, val in self.fun_globals.items():
+            if is_annotated(val):
+                self.vars[var_name] = val.__metadata__[0]
             if isinstance(val, types.ModuleType):
                 annotations = getattr(val, "__annotations__", {})
                 for name, anno in annotations.items():
@@ -341,9 +335,7 @@ class Visitor(ast.NodeTransformer):
                     if isinstance(anno, str):
                         self.vars[name] = anno
 
-    def get_annotations(
-        self, name: str, module: None | str = None
-    ) -> Optional[Dict[str, Any]]:
+    def get_annotations(self, name: str, module: None | str = None) -> Optional[Dict[str, Any]]:
         """Get annotations of a function found in the impunity_func class dict.
         Returns None if the function is not annotated.
 
@@ -360,8 +352,7 @@ class Visitor(ast.NodeTransformer):
                 globals = list(self.impunity_func.values())[-1].__globals__
                 locals = fun.__globals__  # type: ignore
                 annotations = {
-                    k: v if not isinstance(v, str) else eval(v, globals, locals)
-                    for k, v in annotations.items()
+                    k: v if not isinstance(v, str) else eval(v, globals, locals) for k, v in annotations.items()
                 }
                 return cast(Dict[str, Any], annotations)
             # from nested function
@@ -374,8 +365,7 @@ class Visitor(ast.NodeTransformer):
                 globals = list(self.impunity_func.values())[-1].__globals__
                 locals = name.__globals__  # type: ignore
                 annotations = {
-                    k: v if not isinstance(v, str) else eval(v, globals, locals)
-                    for k, v in annotations.items()
+                    k: v if not isinstance(v, str) else eval(v, globals, locals) for k, v in annotations.items()
                 }
                 return cast(Dict[str, Any], annotations)
 
@@ -393,12 +383,9 @@ class Visitor(ast.NodeTransformer):
             method_list = [
                 getattr(self.fun, func)
                 for func in dir(self.fun)
-                if callable(getattr(self.fun, func))
-                and not func.startswith("__")
+                if callable(getattr(self.fun, func)) and not func.startswith("__")
             ]
-            if (
-                init := self.fun.__init__  # type: ignore
-            ).__class__.__name__ != "wrapper_descriptor":
+            if (init := self.fun.__init__).__class__.__name__ != "wrapper_descriptor":  # type: ignore
                 # meaning: does the class have a __init__
                 # (otherwise, it's an empty slot)
                 self.add_func(init)
@@ -424,18 +411,12 @@ class Visitor(ast.NodeTransformer):
         # check for impunity decorator:
         if node.decorator_list:
             for decorator in node.decorator_list:
-                if isinstance(decorator, ast.Call) and isinstance(
-                    decorator.func, ast.Name
-                ):
+                if isinstance(decorator, ast.Call) and isinstance(decorator.func, ast.Name):
                     if decorator.func.id == "impunity":
                         for kw in decorator.keywords:
                             if hasattr(kw, "value"):
-                                if (
-                                    kw.arg == "ignore" and kw.value.value  # type: ignore
-                                ):
-                                    self.impunity_func.pop(
-                                        (self.current_module, node.name), False
-                                    )
+                                if kw.arg == "ignore" and kw.value.value:  # type: ignore
+                                    self.impunity_func.pop((self.current_module, node.name), False)
                                     return node
 
         var_buffer = self.vars
@@ -508,11 +489,7 @@ class Visitor(ast.NodeTransformer):
                 )
         elif isinstance(node, ast.List):
             if not self.ignore_warnings:
-                _log.warning(
-                    self.fun_header(node)
-                    + "lists are not supported by impunity "
-                    + "(but numpy arrays are)"
-                )
+                _log.warning(self.fun_header(node) + "lists are not supported by impunity " + "(but numpy arrays are)")
             return QuantityNode(node, "dimensionless")
 
         elif isinstance(node, ast.Set):
@@ -536,9 +513,7 @@ class Visitor(ast.NodeTransformer):
         elif isinstance(node, ast.Name):
             return QuantityNode(node, self.vars[node.id])
 
-        elif isinstance(node, ast.BinOp) and isinstance(
-            node.op, (ast.Add, ast.Sub)
-        ):
+        elif isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Add, ast.Sub)):
             left = self.get_node_unit(node.left)
             right = self.get_node_unit(node.right)
 
@@ -550,11 +525,7 @@ class Visitor(ast.NodeTransformer):
                 )
 
             if pint.Unit(left.unit).is_compatible_with(pint.Unit(right.unit)):
-                conv_value = (
-                    pint.Unit(left.unit)  # type: ignore
-                    .from_(pint.Unit(right.unit))
-                    .m
-                )
+                conv_value = pint.Unit(left.unit).from_(pint.Unit(right.unit)).m  # type: ignore
                 new_node = ast.BinOp(
                     left.node,  # type:ignore
                     node.op,
@@ -564,9 +535,7 @@ class Visitor(ast.NodeTransformer):
                         ast.Constant(conv_value),
                     ),
                 )
-                return QuantityNode(
-                    ast.copy_location(new_node, node), left.unit
-                )
+                return QuantityNode(ast.copy_location(new_node, node), left.unit)
 
             else:
                 if not self.ignore_warnings:
@@ -577,9 +546,7 @@ class Visitor(ast.NodeTransformer):
                     )
                 return QuantityNode(node, "dimensionless")
 
-        elif isinstance(node, ast.BinOp) and isinstance(
-            node.op, (ast.Mult, ast.Div)
-        ):
+        elif isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Mult, ast.Div)):
             left = self.get_node_unit(node.left)
             right = self.get_node_unit(node.right)
 
@@ -597,11 +564,7 @@ class Visitor(ast.NodeTransformer):
                 right.unit = right.unit.__metadata__[0]
 
             if pint.Unit(left.unit).is_compatible_with(pint.Unit(right.unit)):
-                conv_value = (
-                    pint.Unit(left.unit)  # type: ignore
-                    .from_(pint.Unit(right.unit))
-                    .m
-                )
+                conv_value = pint.Unit(left.unit).from_(pint.Unit(right.unit)).m  # type: ignore
                 new_node = ast.BinOp(
                     left.node,  # type: ignore
                     node.op,
@@ -611,20 +574,12 @@ class Visitor(ast.NodeTransformer):
                         ast.Constant(conv_value),
                     ),
                 )
-                unit = (
-                    f"{left.unit}*{left.unit}"
-                    if isinstance(node.op, ast.Mult)
-                    else "dimensionless"
-                )
+                unit = f"{left.unit}*{left.unit}" if isinstance(node.op, ast.Mult) else "dimensionless"
                 return QuantityNode(ast.copy_location(new_node, node), unit)
 
             else:
                 new_node = ast.BinOp(left.node, node.op, right.node)  # type: ignore
-                unit = (
-                    f"{left.unit}*{right.unit}"
-                    if isinstance(node.op, ast.Mult)
-                    else f"{left.unit}/{right.unit}"
-                )
+                unit = f"{left.unit}*{right.unit}" if isinstance(node.op, ast.Mult) else f"{left.unit}/{right.unit}"
                 return QuantityNode(ast.copy_location(new_node, node), unit)
 
         elif isinstance(node, ast.BinOp) and isinstance(node.op, ast.Pow):
@@ -633,9 +588,7 @@ class Visitor(ast.NodeTransformer):
 
             if left.unit is None:
                 new_node = ast.BinOp(left.node, node.op, right.node)  # type: ignore
-                return QuantityNode(
-                    ast.copy_location(new_node, node), left.unit
-                )
+                return QuantityNode(ast.copy_location(new_node, node), left.unit)
 
             if is_annotated(left.unit):
                 left.unit = left.unit.__metadata__[0]
@@ -665,29 +618,15 @@ class Visitor(ast.NodeTransformer):
             elif isinstance(right.node, ast.BinOp):
                 pow_right = right.node.right
                 pow_left = right.node.left
-                if isinstance(pow_left, ast.Constant) and isinstance(
-                    pow_right, ast.Constant
-                ):
+                if isinstance(pow_left, ast.Constant) and isinstance(pow_right, ast.Constant):
                     if isinstance(right.node.op, ast.Mult):
-                        unit = (
-                            f"({left.unit})^({pow_left.value}"
-                            + f"*{pow_right.value})"
-                        )
+                        unit = f"({left.unit})^({pow_left.value}" + f"*{pow_right.value})"
                     elif isinstance(right.node.op, ast.Div):
-                        unit = (
-                            f"({left.unit})^({pow_left.value}"
-                            + f"/{pow_right.value})"
-                        )
+                        unit = f"({left.unit})^({pow_left.value}" + f"/{pow_right.value})"
                     elif isinstance(right.node.op, ast.Add):
-                        unit = (
-                            f"({left.unit})^({pow_left.value}"
-                            + f"+{pow_right.value})"
-                        )
+                        unit = f"({left.unit})^({pow_left.value}" + f"+{pow_right.value})"
                     elif isinstance(right.node.op, ast.Sub):
-                        unit = (
-                            f"({left.unit})^({pow_left.value}"
-                            + f"-{pow_right.value})"
-                        )
+                        unit = f"({left.unit})^({pow_left.value}" + f"-{pow_right.value})"
                     else:
                         if not self.ignore_warnings:
                             _log.warning(
@@ -723,20 +662,14 @@ class Visitor(ast.NodeTransformer):
 
             if not (right.unit is None or right.unit == "dimensionless"):
                 if not self.ignore_warnings:
-                    _log.warning(
-                        self.fun_header(node)
-                        + "The modulo must be dimensionless"
-                    )
+                    _log.warning(self.fun_header(node) + "The modulo must be dimensionless")
 
             new_node = ast.BinOp(left.node, node.op, right.node)  # type: ignore
             return QuantityNode(new_node, left.unit)
 
         elif isinstance(node, ast.BinOp):
             if not self.ignore_warnings:
-                _log.warning(
-                    self.fun_header(node)
-                    + "Binary Operation not supported yet."
-                )
+                _log.warning(self.fun_header(node) + "Binary Operation not supported yet.")
             return QuantityNode(node, None)
 
         elif isinstance(node, ast.IfExp):
@@ -751,15 +684,10 @@ class Visitor(ast.NodeTransformer):
 
             if body.unit != orelse.unit:
                 if not self.ignore_warnings:
-                    _log.warning(
-                        self.fun_header(node)
-                        + "Ternary operator with mixed units."
-                    )
+                    _log.warning(self.fun_header(node) + "Ternary operator with mixed units.")
                 return QuantityNode(ast.copy_location(new_node, node), None)
             else:
-                return QuantityNode(
-                    ast.copy_location(new_node, node), body.unit
-                )
+                return QuantityNode(ast.copy_location(new_node, node), body.unit)
 
         elif isinstance(node, ast.Call):
             node = self.generic_visit(node)  # type: ignore
@@ -777,11 +705,7 @@ class Visitor(ast.NodeTransformer):
             offset = 0
 
             # if not a known impunity function or no return signature
-            if (
-                signature is None
-                or not signature
-                or list(signature.items())[-1][0] != "return"
-            ):
+            if signature is None or not signature or list(signature.items())[-1][0] != "return":
                 return QuantityNode(node, None)
             else:
                 fun_signature = list(signature.items())[:-1]
@@ -807,16 +731,10 @@ class Visitor(ast.NodeTransformer):
                         new_args.append(arg)
                         continue
 
-                    received.unit = (
-                        received.unit.__metadata__[0]
-                        if is_annotated(received.unit)
-                        else received.unit
-                    )
+                    received.unit = received.unit.__metadata__[0] if is_annotated(received.unit) else received.unit
 
                     assert received.node is not None
-                    new_arg = self.node_convert(
-                        expected, received.unit, received.node
-                    )
+                    new_arg = self.node_convert(expected, received.unit, received.node)
                     new_args.append(new_arg)
 
             new_node = (
@@ -830,9 +748,7 @@ class Visitor(ast.NodeTransformer):
             )
 
             return_unit = (
-                return_signature[1].__metadata__[0]
-                if is_annotated(return_signature[1])
-                else return_signature[1]
+                return_signature[1].__metadata__[0] if is_annotated(return_signature[1]) else return_signature[1]
             )
 
             return QuantityNode(ast.copy_location(new_node, node), return_unit)
@@ -877,38 +793,27 @@ class Visitor(ast.NodeTransformer):
             else:
                 return node
             for i, arg in enumerate(node.args):
-                if (received := self.get_node_unit(arg)).unit != (
-                    expected := fun_signature[i][1]
-                ):
+                if (received := self.get_node_unit(arg)).unit != (expected := fun_signature[i][1]):
                     if is_annotated(expected):
                         expected = expected.__metadata__[0]
                     assert received.node is not None
-                    new_arg = self.node_convert(
-                        expected, received.unit, received.node
-                    )
+                    new_arg = self.node_convert(expected, received.unit, received.node)
                     new_args.append(new_arg)
                 else:
                     new_args.append(arg)
 
             for keyword in node.keywords:
                 if keyword.arg:
-                    if (received := self.get_node_unit(keyword.value)) != (
-                        expected := signature[keyword.arg]
-                    ):
+                    if (received := self.get_node_unit(keyword.value)) != (expected := signature[keyword.arg]):
                         if is_annotated(expected):
                             x = expected.__metadata__[0]
                             expected = x
-                        if not (
-                            isinstance(expected, str)
-                            and isinstance(received.unit, str)
-                        ):
+                        if not (isinstance(expected, str) and isinstance(received.unit, str)):
                             # TODO To avoid annoying typing for now
                             return node
 
                         assert received.node is not None
-                        new_value = self.node_convert(
-                            expected, received.unit, received.node
-                        )
+                        new_value = self.node_convert(expected, received.unit, received.node)
 
                         new_keyword = cast(
                             ast.expr,
@@ -1058,10 +963,7 @@ class Visitor(ast.NodeTransformer):
         for target in node.targets:
             if isinstance(target, ast.Tuple):
                 received = (
-                    [
-                        arg.__metadata__[0] if is_annotated(arg) else arg
-                        for arg in value.unit.__args__
-                    ]
+                    [arg.__metadata__[0] if is_annotated(arg) else arg for arg in value.unit.__args__]
                     if hasattr(value.unit, "__args__")
                     else value.unit
                 )
@@ -1076,9 +978,7 @@ class Visitor(ast.NodeTransformer):
                 if target.id in self.vars:
                     expected = self.vars[target.id]
                     assert value.node is not None
-                    new_value = self.node_convert(
-                        expected, value.unit, value.node
-                    )
+                    new_value = self.node_convert(expected, value.unit, value.node)
                     new_node = ast.Assign(
                         targets=node.targets,
                         value=new_value,
@@ -1118,10 +1018,7 @@ class Visitor(ast.NodeTransformer):
             ret = return_annotation.get("return", None)
             if ret is None:
                 if not self.ignore_warnings:
-                    _log.info(
-                        self.fun_header(node)
-                        + "Some return annotations are missing"
-                    )
+                    _log.info(self.fun_header(node) + "Some return annotations are missing")
                 new_node = node
                 return ast.copy_location(new_node, node)
 
@@ -1147,10 +1044,7 @@ class Visitor(ast.NodeTransformer):
 
         else:  # is None
             if not self.ignore_warnings:
-                _log.info(
-                    self.fun_header(node)
-                    + "Some return annotations are missing"
-                )
+                _log.info(self.fun_header(node) + "Some return annotations are missing")
             new_node = node
             return ast.copy_location(new_node, node)
 
@@ -1162,24 +1056,16 @@ class Visitor(ast.NodeTransformer):
                 new_node = node
             else:
                 if not self.ignore_warnings:
-                    _log.warning(
-                        self.fun_header(node)
-                        + "Expected more than one return value"
-                    )
+                    _log.warning(self.fun_header(node) + "Expected more than one return value")
                 new_node = node
         else:
             if isinstance(received.unit, list):
                 if not self.ignore_warnings:
-                    _log.warning(
-                        self.fun_header(node)
-                        + "Expected more than one return value"
-                    )
+                    _log.warning(self.fun_header(node) + "Expected more than one return value")
                 new_node = node
             else:
                 assert received.node is not None
-                new_value = self.node_convert(
-                    expected, received.unit, received.node
-                )
+                new_value = self.node_convert(expected, received.unit, received.node)
                 new_node = ast.Return(value=new_value)
 
         return ast.copy_location(new_node, node)

--- a/src/impunity/visitor.py
+++ b/src/impunity/visitor.py
@@ -282,8 +282,8 @@ class Visitor(ast.NodeTransformer):
 
                 elif (e1.m - e0.m) == 1:
                     conv_value = (
-                        expected_pint_unit.from_(received_pint_unit).m
-                    ) - 1  # type: ignore
+                        expected_pint_unit.from_(received_pint_unit).m  # type: ignore
+                    ) - 1
 
                     # if conv_value == 0:
                     #     new_node = received_node

--- a/src/impunity/visitor.py
+++ b/src/impunity/visitor.py
@@ -157,7 +157,7 @@ class Visitor(ast.NodeTransformer):
 
         # case where node's parent is an AnnAssign
         elif isinstance(node, ast.Name):
-            if isinstance(node.parent, ast.AnnAssign):
+            if isinstance(node.parent, ast.AnnAssign):  # type: ignore
                 unit = self.get_node_unit(node).unit
 
         return unit
@@ -400,8 +400,8 @@ class Visitor(ast.NodeTransformer):
                 and not func.startswith("__")
             ]
             if (
-                init := self.fun.__init__
-            ).__class__.__name__ != "wrapper_descriptor":  # type: ignore
+                init := self.fun.__init__  # type: ignore
+            ).__class__.__name__ != "wrapper_descriptor":
                 # meaning: does the class have a __init__
                 # (otherwise, it's an empty slot)
                 self.add_func(init)

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -10,7 +10,9 @@ meters_per_second = Annotated[float, "m/s"]
 
 
 @impunity
-def speed_to_test(d: Annotated[Any, "m"], t: Annotated[Any, "s"]) -> Annotated[Any, "m/s"]:
+def speed_to_test(
+    d: Annotated[Any, "m"], t: Annotated[Any, "s"]
+) -> Annotated[Any, "m/s"]:
     return d / t
 
 
@@ -22,5 +24,7 @@ def speed_altitude_to_test(
 
 
 @impunity
-def speed_with_annotated_to_test(distance: meters, time: seconds) -> meters_per_second:
+def speed_with_annotated_to_test(
+    distance: meters, time: seconds
+) -> meters_per_second:
     return distance / time

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -2,11 +2,12 @@ from typing import Any
 
 from typing_extensions import Annotated
 
+import numpy.typing as npt
 from impunity import impunity
 
 meters = Annotated[float, "m"]
 seconds = Annotated[float, "s"]
-meters_per_second = Annotated[float, "m/s"]
+meters_per_second = Annotated[npt.NDArray, "m/s"]
 
 
 @impunity

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -2,8 +2,8 @@ from typing import Any
 
 from typing_extensions import Annotated
 
-import numpy.typing as npt
 import numpy as np
+import numpy.typing as npt
 from impunity import impunity
 
 NDArrayFloat = npt.NDArray[np.float64]

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -3,7 +3,8 @@ from typing import Any
 from typing_extensions import Annotated
 
 from impunity import impunity
-from numpy import npt
+import numpy.typing as npt
+
 
 meters = Annotated[npt.ArrayLike, "m"]
 seconds = Annotated[float, "s"]

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -5,7 +5,7 @@ from typing_extensions import Annotated
 import numpy.typing as npt
 from impunity import impunity
 
-meters = Annotated[float, "m"]
+meters = Annotated[npt.NDArray, "m"]
 seconds = Annotated[float, "s"]
 meters_per_second = Annotated[npt.NDArray, "m/s"]
 

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -2,12 +2,12 @@ from typing import Any
 
 from typing_extensions import Annotated
 
-import numpy.typing as npt
+import numpy as np
 from impunity import impunity
 
-meters = Annotated[npt.NDArray, "m"]
+meters = Annotated[np.ndarray[Any], "m"]
 seconds = Annotated[float, "s"]
-meters_per_second = Annotated[npt.NDArray, "m/s"]
+meters_per_second = Annotated[np.ndarray[Any], "m/s"]
 
 
 @impunity

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -3,11 +3,13 @@ from typing import Any
 from typing_extensions import Annotated
 
 import numpy.typing as npt
+import numpy as np
 from impunity import impunity
 
-meters = Annotated[npt.ArrayLike, "m"]
+NDArrayFloat = npt.NDArray[np.float64]
+meters = Annotated[NDArrayFloat, "m"]
 seconds = Annotated[float, "s"]
-meters_per_second = Annotated[npt.ArrayLike, "m/s"]
+meters_per_second = Annotated[NDArrayFloat, "m/s"]
 
 
 @impunity

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -4,11 +4,13 @@ from typing_extensions import Annotated
 
 from impunity import impunity
 
+meters = Annotated[float, "m"]
+seconds = Annotated[float, "s"]
+meters_per_second = Annotated[float, "m/s"]
+
 
 @impunity
-def speed_to_test(
-    d: Annotated[Any, "m"], t: Annotated[Any, "s"]
-) -> Annotated[Any, "m/s"]:
+def speed_to_test(d: Annotated[Any, "m"], t: Annotated[Any, "s"]) -> Annotated[Any, "m/s"]:
     return d / t
 
 
@@ -17,3 +19,8 @@ def speed_altitude_to_test(
     d: Annotated[Any, "m"], t: Annotated[Any, "s"], a: Annotated[Any, "m"] = 0
 ) -> Annotated[Any, "m/s"]:
     return d / t + a * 1.3654
+
+
+@impunity
+def speed_with_annotated_to_test(distance: meters, time: seconds) -> meters_per_second:
+    return distance / time

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -2,12 +2,12 @@ from typing import Any
 
 from typing_extensions import Annotated
 
-import numpy as np
 from impunity import impunity
+from numpy import npt
 
-meters = Annotated[np.ndarray[Any], "m"]
+meters = Annotated[npt.ArrayLike, "m"]
 seconds = Annotated[float, "s"]
-meters_per_second = Annotated[np.ndarray[Any], "m/s"]
+meters_per_second = Annotated[npt.ArrayLike, "m/s"]
 
 
 @impunity

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -2,9 +2,8 @@ from typing import Any
 
 from typing_extensions import Annotated
 
-from impunity import impunity
 import numpy.typing as npt
-
+from impunity import impunity
 
 meters = Annotated[npt.ArrayLike, "m"]
 seconds = Annotated[float, "s"]

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -4,7 +4,6 @@ from typing_extensions import Annotated
 
 import numpy as np
 from impunity import impunity
-import numpy as np
 
 meters = Annotated[np.ndarray[Any], "m"]
 seconds = Annotated[float, "s"]

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -7,6 +7,7 @@ from typing_extensions import Annotated
 
 import numpy as np
 from impunity import impunity
+from numpy import npt
 
 from .sample_module import (
     speed_altitude_to_test,
@@ -223,9 +224,7 @@ class Functions(unittest.TestCase):
     @impunity
     def test_conversion_with_module(self) -> None:
         # Using meters instead of Annotated[float, "m"]
-        altitudes: Annotated[np.ndarray[Any], "meters"] = np.arange(
-            0, 1000, 100
-        )
+        altitudes: Annotated[npt.ArrayLike, "meters"] = np.arange(0, 1000, 100)
         duration: Annotated[float, "min"] = 100
         result = speed_with_annotated_to_test(altitudes, duration)
         self.assertAlmostEqual(result[3], 0.05, delta=1e-2)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -224,7 +224,9 @@ class Functions(unittest.TestCase):
     @impunity
     def test_conversion_with_module(self) -> None:
         # Using meters instead of Annotated[float, "m"]
-        altitudes: Annotated[npt.NDArray, "meters"] = np.arange(0, 1000, 100)
+        altitudes: Annotated[np.ndarray[Any], "meters"] = np.arange(
+            0, 1000, 100
+        )
         duration: Annotated[float, "min"] = 100
         result = speed_with_annotated_to_test(altitudes, duration)
         self.assertAlmostEqual(result[3], 0.05, delta=1e-2)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -219,6 +219,7 @@ class Functions(unittest.TestCase):
         altitudes = np.arange(0, 1000, 100)
         duration: Annotated[float, "min"] = 100
         result = speed_with_annotated_to_test(altitudes, duration)
+        self.assertAlmostEqual(result[3], 0.05, delta=1e-2)
 
 
 if __name__ == "__main__":

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -222,7 +222,6 @@ class Functions(unittest.TestCase):
 
     @impunity
     def test_conversion_with_module(self) -> None:
-
         # Using meters instead of Annotated[float, "m"]
         altitudes = np.arange(0, 1000, 100)
         duration: Annotated[float, "min"] = 100

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -7,7 +7,8 @@ from typing_extensions import Annotated
 
 import numpy as np
 from impunity import impunity
-from numpy import npt
+import numpy.typing as npt
+
 
 from .sample_module import (
     speed_altitude_to_test,

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -224,7 +224,7 @@ class Functions(unittest.TestCase):
     @impunity
     def test_conversion_with_module(self) -> None:
         # Using meters instead of Annotated[float, "m"]
-        altitudes: Annotated[npt.ArrayLike, "meters"] = np.arange(0, 1000, 100)
+        altitudes: Annotated[Any, "meters"] = np.arange(0, 1000, 100)
         duration: Annotated[float, "min"] = 100
         result = speed_with_annotated_to_test(altitudes, duration)
         self.assertAlmostEqual(result[3], 0.05, delta=1e-2)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -8,7 +8,11 @@ from typing_extensions import Annotated
 import numpy as np
 from impunity import impunity
 
-from .sample_module import speed_altitude_to_test, speed_to_test, speed_with_annotated_to_test
+from .sample_module import (
+    speed_altitude_to_test,
+    speed_to_test,
+    speed_with_annotated_to_test,
+)
 
 m = Annotated[Any, "m"]
 K = Annotated[Any, "K"]
@@ -71,7 +75,9 @@ def temperature_3(altitude_m: "m") -> Annotated[Any, "celsius"]:
 
 
 @impunity
-def tas2mach(tas: Annotated[Any, "kts"], h: Annotated[Any, "ft"]) -> Annotated[Any, "dimensionless"]:
+def tas2mach(
+    tas: Annotated[Any, "kts"], h: Annotated[Any, "ft"]
+) -> Annotated[Any, "dimensionless"]:
     """
     :param tas: True Air Speed, (by default in kts)
     :param h: altitude, (by default in ft)
@@ -177,7 +183,9 @@ class Functions(unittest.TestCase):
 
         with self.assertLogs("impunity.visitor", level="INFO") as cm:
             impunity(test_empty_return)
-        self.assertTrue(cm.output[0].endswith("Some return annotations are missing"))
+        self.assertTrue(
+            cm.output[0].endswith("Some return annotations are missing")
+        )
 
     def test_return_convert(self) -> None:
         @impunity

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import unittest
 from typing import Any, Tuple
-import numpy.typing as npt
 
 from typing_extensions import Annotated
 
 import numpy as np
+import numpy.typing as npt
 from impunity import impunity
 
 from .sample_module import (

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -8,7 +8,7 @@ from typing_extensions import Annotated
 import numpy as np
 from impunity import impunity
 
-from .sample_module import speed_altitude_to_test, speed_to_test
+from .sample_module import speed_altitude_to_test, speed_to_test, speed_with_annotated_to_test
 
 m = Annotated[Any, "m"]
 K = Annotated[Any, "K"]
@@ -71,9 +71,7 @@ def temperature_3(altitude_m: "m") -> Annotated[Any, "celsius"]:
 
 
 @impunity
-def tas2mach(
-    tas: Annotated[Any, "kts"], h: Annotated[Any, "ft"]
-) -> Annotated[Any, "dimensionless"]:
+def tas2mach(tas: Annotated[Any, "kts"], h: Annotated[Any, "ft"]) -> Annotated[Any, "dimensionless"]:
     """
     :param tas: True Air Speed, (by default in kts)
     :param h: altitude, (by default in ft)
@@ -179,9 +177,7 @@ class Functions(unittest.TestCase):
 
         with self.assertLogs("impunity.visitor", level="INFO") as cm:
             impunity(test_empty_return)
-        self.assertTrue(
-            cm.output[0].endswith("Some return annotations are missing")
-        )
+        self.assertTrue(cm.output[0].endswith("Some return annotations are missing"))
 
     def test_return_convert(self) -> None:
         @impunity
@@ -215,6 +211,14 @@ class Functions(unittest.TestCase):
         self.assertAlmostEqual(res, 417.17, delta=1e-2)
         res2 = speed_altitude_to_test(d, t)
         self.assertAlmostEqual(res2, 1, delta=1e-2)
+
+    @impunity
+    def test_conversion_with_module(self) -> None:
+
+        # Using meters instead of Annotated[float, "m"]
+        altitudes = np.arange(0, 1000, 100)
+        duration: Annotated[float, "min"] = 100
+        result = speed_with_annotated_to_test(altitudes, duration)
 
 
 if __name__ == "__main__":

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -6,9 +6,8 @@ from typing import Any, Tuple
 from typing_extensions import Annotated
 
 import numpy as np
-from impunity import impunity
 import numpy.typing as npt
-
+from impunity import impunity
 
 from .sample_module import (
     speed_altitude_to_test,

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -6,7 +6,6 @@ from typing import Any, Tuple
 from typing_extensions import Annotated
 
 import numpy as np
-import numpy.typing as npt
 from impunity import impunity
 
 from .sample_module import (

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import unittest
 from typing import Any, Tuple
+import numpy.typing as npt
 
 from typing_extensions import Annotated
 
@@ -223,7 +224,7 @@ class Functions(unittest.TestCase):
     @impunity
     def test_conversion_with_module(self) -> None:
         # Using meters instead of Annotated[float, "m"]
-        altitudes = np.arange(0, 1000, 100)
+        altitudes: Annotated[npt.NDArray, "meters"] = np.arange(0, 1000, 100)
         duration: Annotated[float, "min"] = 100
         result = speed_with_annotated_to_test(altitudes, duration)
         self.assertAlmostEqual(result[3], 0.05, delta=1e-2)


### PR DESCRIPTION
## Adding typing.Annotation from module level

For impunised functions in unimpunised modules, we check for Annotated assignments to ensure they are taken into account in the functions.

Example : 
```

from typing import Annotated

meters = Annotated[Any, "m"]

@impunity
def fun(m : meters ) :
...
```

Added tests to ensure it all works out

## Changing Numpy's random.rand to random Generators

With Python 3.12 and latest numpy version, Ruff was not happy with the random.rand, so I had to update it to generators.
